### PR TITLE
Feature/use event responder

### DIFF
--- a/LICENSE
+++ b/LICENSE
@@ -1,21 +1,35 @@
-MIT License
 
-Copyright (c) 2021 Frank
+   Wavefile player 
+   Copyright (c) 2021, Frank Bösing, f.boesing @ gmx (dot) de
+   
+   for 
+   
+   Audio Library for Teensy
+   Copyright (c) 2014, Paul Stoffregen, paul@pjrc.com
 
-Permission is hereby granted, free of charge, to any person obtaining a copy
-of this software and associated documentation files (the "Software"), to deal
-in the Software without restriction, including without limitation the rights
-to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
-copies of the Software, and to permit persons to whom the Software is
-furnished to do so, subject to the following conditions:
+   
+   Development of this audio library was funded by PJRC.COM, LLC by sales of
+   Teensy and Audio Adaptor boards.  Please support PJRC's efforts to develop
+   open source software by purchasing Teensy or other PJRC products.
 
-The above copyright notice and this permission notice shall be included in all
-copies or substantial portions of the Software.
+   Permission is hereby granted, free of charge, to any person obtaining a copy
+   of this software and associated documentation files (the "Software"), to deal
+   in the Software without restriction, including without limitation the rights
+   to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+   copies of the Software, and to permit persons to whom the Software is
+   furnished to do so, subject to the following conditions:
 
-THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
-IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
-FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
-AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
-LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
-OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
-SOFTWARE.
+   The above copyright notice, development funding notice, and this permission
+   notice shall be included in all copies or substantial portions of the Software.
+
+   THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+   IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+   FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+   AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+   LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+   OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+   THE SOFTWARE.
+
+
+   Addition by Frank Bösing:
+   Use of this code (wavefile player) permitted for use with hardware developed by PJRC only.

--- a/examples/WavFilePlayerI2S/WavFilePlayerI2S.ino
+++ b/examples/WavFilePlayerI2S/WavFilePlayerI2S.ino
@@ -35,7 +35,7 @@
 AudioPlayWav             playWav;     //xy=323,171
 AudioMixer4              mixer1;         //xy=647,123
 AudioMixer4              mixer3;         //xy=648,212
-AudioOutputPT8211        pt8211_1;       //xy=828,169
+AudioOutputI2S        pt8211_1;       //xy=828,169
 AudioConnection          patchCord1(playWav, 0, mixer1, 0);
 AudioConnection          patchCord2(playWav, 1, mixer3, 0);
 AudioConnection          patchCord3(playWav, 2, mixer1, 1);
@@ -46,6 +46,7 @@ AudioConnection          patchCord7(playWav, 6, mixer1, 3);
 AudioConnection          patchCord8(playWav, 7, mixer3, 3);
 AudioConnection          patchCord9(mixer1, 0, pt8211_1, 0);
 AudioConnection          patchCord10(mixer3, 0, pt8211_1, 1);
+AudioControlSGTL5000     sgtl5000_1;     //xy=853,409
 // GUItool: end automatically generated code
 
 #define SDCARD_CS_PIN    BUILTIN_SDCARD
@@ -68,17 +69,17 @@ void setup() {
 
   SPI.setMOSI(SDCARD_MOSI_PIN);
   SPI.setSCK(SDCARD_SCK_PIN);
-  if (!(SD.begin(SDCARD_CS_PIN))) {
+  while (!(SD.begin(SDCARD_CS_PIN))) {
     // stop here, but print a message repetitively
-    while (1) {
+    //while (1) {
       Serial.println("Unable to access the SD card");
       delay(500);
-    }
+    //}
   }
 
-  // load data from SD file during update() interrupt,
-  // not via EventResponder
-  playWav.enableEventReading(false);
+  sgtl5000_1.enable();
+  sgtl5000_1.volume(0.5);
+ 
 }
 
 void playFile(const char *filename)
@@ -86,20 +87,31 @@ void playFile(const char *filename)
   Serial.print("Playing file: ");
   Serial.println(filename);
   playWav.play(filename);
-  while (playWav.isPlaying()) {}
+  while (playWav.isPlaying()) 
+  {
+    // Needed for EventResponder: could instead call yield(), 
+    // or switch to old scheme of reading SD inside the update() loop
+    // by executing playWav.enableEventReading(false)
+    delay(10); 
+  }
 }
 
 
 void loop() {
-  //playFile("Nums_7dot1_16_44100.wav");
+  playFile("Nums_7dot1_16_44100.wav");
+  delay(500);
   playFile("Nums_7dot1_8_44100.wav");
   delay(500);
-  playFile("SDTEST1.WAV");  // filenames are always uppercase 8.3 format
+  playFile("sine110.wav");
   delay(500);
-  playFile("SDTEST2.WAV");
+  playFile("sine220.wav");
   delay(500);
-  playFile("SDTEST3.WAV");
+  playFile("sine330.wav");
   delay(500);
-  playFile("SDTEST4.WAV");
+  playFile("sine440.wav");
+  delay(500);
+  playFile("sine550.wav");
+  delay(500);
+  playFile("sine660.wav");
   delay(1500);
 }

--- a/play_wav.cpp
+++ b/play_wav.cpp
@@ -384,8 +384,6 @@ void  AudioPlayWav::update(void)
 	
 	if (nullptr == currentPos)
 		return;
-	else
-		currentPos += buffer_rd; // position in buffer
 
 	// allocate the audio blocks to transmit
     audio_block_t *queue[channels];
@@ -403,8 +401,8 @@ void  AudioPlayWav::update(void)
 
 
 	// copy the samples to the audio blocks:
-    decoder(buffer, &buffer_rd, queue, channels);
-        if (buffer_rd >= sz_mem ) buffer_rd = 0;
+    decoder(currentPos, &buffer_rd, queue, channels);
+    if (buffer_rd >= sz_mem ) buffer_rd = 0;
 
 	// transmit them:
     chan = 0;

--- a/play_wav.cpp
+++ b/play_wav.cpp
@@ -60,7 +60,7 @@ static uint8_t _sz_mem_additional = 1;
 #endif
 
 //----------------------------------------------------------------------------------------------------
-static bool WavMover::eventReadingEnabled = true; //!< true to read in EventResponder, otherwise reads happen under interrupt
+bool WavMover::eventReadingEnabled = true; //!< true to read in EventResponder, otherwise reads happen under interrupt
 /*
  * Initialise utility to move data from SD card to memory (or vice versa in the future?).
  */
@@ -114,6 +114,14 @@ void AudioPlayWav::begin(void)
 #if !defined(KINETISL)
     my_instance = _AudioPlayWavInstances;
     ++_AudioPlayWavInstances;
+#endif
+}
+
+void AudioPlayWav::end(void)
+{
+	stop();
+#if !defined(KINETISL)
+    --_AudioPlayWavInstances;
 #endif
 }
 
@@ -411,11 +419,7 @@ void  AudioPlayWav::update(void)
 	if (data_length <= 0) stop();
 	
 	// trigger buffer fill if we just emptied it
-#if defined(KINETISL)
     if ( buffer_rd == 0)
-#else
-    if (/*_AudioPlayWavInstance == my_instance &&*/ buffer_rd == 0 )
-#endif
     {
         wavMovr.readLater();
     }
@@ -596,7 +600,7 @@ uint8_t AudioPlayWav::instanceID(void)
 
 File AudioPlayWav::file(void)
 {
-    return wavfile;
+    return wavMovr.wavfile;
 }
 
 uint32_t AudioPlayWav::filePos(void)

--- a/play_wav.cpp
+++ b/play_wav.cpp
@@ -60,7 +60,7 @@ static uint8_t _sz_mem_additional = 1;
 #endif
 
 //----------------------------------------------------------------------------------------------------
-bool WavMover::eventReadingEnabled = true; //!< true to read in EventResponder, otherwise reads happen under interrupt
+bool WavMover::eventReadingEnabled = false; //!< true to read in EventResponder, otherwise reads happen under interrupt
 /*
  * Initialise utility to move data from SD card to memory (or vice versa in the future?).
  */

--- a/play_wav.cpp
+++ b/play_wav.cpp
@@ -34,7 +34,7 @@
 #define STATE_PAUSED  1
 #define STATE_PLAY    2
 
-//#define HANDLE_SPI    1
+//#define HANDLE_SPI    1 //TODO...
 
 #if defined(KINETISL)
 static const uint8_t _AudioPlayWavInstances = 1;
@@ -333,7 +333,7 @@ void  AudioPlayWav::update(void)
 
     if ( state != STATE_PLAY ) return;
 
-    if (_AudioPlayWavInstance == my_instance && buffer_rd == 0 )
+    if (/*_AudioPlayWavInstance == my_instance &&*/ buffer_rd == 0 )
 #endif
     {
         size_t rd = wavfile.read(buffer, sz_mem);
@@ -343,7 +343,7 @@ void  AudioPlayWav::update(void)
             memset(&buffer[rd], (bytes == 1) ? 128:0 , sz_mem - rd);
         }
     }
-    
+
     unsigned int chan;
 
 	// allocate the audio blocks to transmit
@@ -424,7 +424,7 @@ void  AudioPlayWav::update(void)
 		AudioStream::transmit(queue[chan], chan);
 		AudioStream::release(queue[chan]);
 	} while (++chan < channels);
-    
+
     //Serial.printf("%d\n",data_length);
     --data_length;
 	if (data_length <= 0) stop();
@@ -448,6 +448,8 @@ void AudioPlayWav::startInt(bool enabled)
 
 void AudioPlayWav::startUsingSPI(void)
 {
+//TODO... https://forum.pjrc.com/threads/67989-Teensyduino-1-55-Beta-1?p=287023&viewfull=1#post287023
+//this must be smarter.
 #if defined(HANDLE_SPI)
 #if defined(HAS_KINETIS_SDHC)
    if (!(SIM_SCGC3 & SIM_SCGC3_SDHC)) AudioStartUsingSPI();
@@ -458,7 +460,7 @@ void AudioPlayWav::startUsingSPI(void)
 }
 
 void AudioPlayWav::stopUsingSPI(void)
-{
+{ //TODO...
 #if defined(HANDLE_SPI)
 #if defined(HAS_KINETIS_SDHC)
     if (!(SIM_SCGC3 & SIM_SCGC3_SDHC)) AudioStopUsingSPI();
@@ -468,14 +470,14 @@ void AudioPlayWav::stopUsingSPI(void)
 #endif
 }
 
-#if !defined(KINETISL)
-bool AudioPlayWav::addMemoryForRead(size_t mult)
+bool AudioPlayWav::addMemoryForRead(__attribute__ ((unused)) size_t mult)
 {
+#if !defined(KINETISL)
     if (mult < 1) mult = 1;
 	_sz_mem_additional = mult;
+#endif
 	return true;
 }
-#endif
 
 bool AudioPlayWav::isPlaying(void)
 {
@@ -490,6 +492,7 @@ void AudioPlayWav::togglePlayPause(void)
 void AudioPlayWav::pause(const bool pause)
 {
     if (state == STATE_STOP) return;
+    bool irq = stopInt();
     if (pause)
     {
         state = STATE_PAUSED;
@@ -498,6 +501,7 @@ void AudioPlayWav::pause(const bool pause)
         startUsingSPI();
         state = STATE_PLAY;
     }
+    startInt(irq);
 }
 
 bool AudioPlayWav::isPaused(void)
@@ -511,11 +515,33 @@ bool AudioPlayWav::isStopped(void)
     return (state == STATE_STOP);
 }
 
+__attribute__( ( always_inline ) ) static inline uint32_t __ldrexw(volatile uint32_t *addr)
+{
+   uint32_t result;
+   asm volatile ("ldrex %0, [%1]" : "=r" (result) : "r" (addr) );
+   return(result);
+}
+
+__attribute__( ( always_inline ) ) static inline uint32_t __strexw(uint32_t value, volatile uint32_t *addr)
+{
+   uint32_t result;
+   asm volatile ("strex %0, %2, [%1]" : "=&r" (result) : "r" (addr), "r" (value) );
+   return(result);
+}
 
 uint32_t AudioPlayWav::positionMillis(void)
 {
-    return (AUDIO_BLOCK_SAMPLES * 1000.0f / AUDIO_SAMPLE_RATE_EXACT) *
-        (total_length / (bytes * sz_frame) - data_length);
+    uint32_t safe_read, ret;
+    //use an interrupt detector to make sure all vars are consistent.
+    //strex will fail if an interrupt occured. An other way would be to block audio interrupts.
+    do
+    {
+        __ldrexw(&safe_read);
+        ret = (AUDIO_BLOCK_SAMPLES * 1000.0f / AUDIO_SAMPLE_RATE_EXACT) *
+              (total_length / (bytes * sz_frame) - data_length);
+	} while ( __strexw(1, &safe_read));
+
+    return ret;
 }
 
 

--- a/play_wav.h
+++ b/play_wav.h
@@ -1,30 +1,39 @@
-/* Audio Library for Teensy
- * Copyright (c) 2014, Paul Stoffregen, paul@pjrc.com
- *
- * Development of this audio library was funded by PJRC.COM, LLC by sales of
- * Teensy and Audio Adaptor boards.  Please support PJRC's efforts to develop
- * open source software by purchasing Teensy or other PJRC products.
- *
- * Permission is hereby granted, free of charge, to any person obtaining a copy
- * of this software and associated documentation files (the "Software"), to deal
- * in the Software without restriction, including without limitation the rights
- * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
- * copies of the Software, and to permit persons to whom the Software is
- * furnished to do so, subject to the following conditions:
- *
- * The above copyright notice, development funding notice, and this permission
- * notice shall be included in all copies or substantial portions of the Software.
- *
- * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
- * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
- * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
- * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
- * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
- * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
- * THE SOFTWARE.
- */
+/* 
+   Wavefile player 
+   Copyright (c) 2021, Frank Bösing, f.boesing @ gmx (dot) de
+   
+   for 
+   
+   Audio Library for Teensy
+   Copyright (c) 2014, Paul Stoffregen, paul@pjrc.com
 
-// (c) Frank Bösing, 07/2021
+   
+   Development of this audio library was funded by PJRC.COM, LLC by sales of
+   Teensy and Audio Adaptor boards.  Please support PJRC's efforts to develop
+   open source software by purchasing Teensy or other PJRC products.
+
+   Permission is hereby granted, free of charge, to any person obtaining a copy
+   of this software and associated documentation files (the "Software"), to deal
+   in the Software without restriction, including without limitation the rights
+   to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+   copies of the Software, and to permit persons to whom the Software is
+   furnished to do so, subject to the following conditions:
+
+   The above copyright notice, development funding notice, and this permission
+   notice shall be included in all copies or substantial portions of the Software.
+
+   THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+   IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+   FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+   AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+   LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+   OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+   THE SOFTWARE.
+
+
+   Addition by Frank Bösing:
+   Use of this code (wavefile player) permitted for use with hardware developed by PJRC only.
+*/
 
 #pragma once
 
@@ -205,6 +214,7 @@ public:
 	size_t memUsed(void);
 	size_t memRead(void);
 	uint8_t instanceID(void);
+    File file(void);
 	virtual void update(void);
 	void enableEventReading(bool enable) { wavMovr.enableEventReading(enable); }
 	float getCPUload() { return CYCLE_COUNTER_APPROX_PERCENT(wavMovr.lastReadLoad); }

--- a/play_wav.h
+++ b/play_wav.h
@@ -55,9 +55,7 @@ public:
 	bool play(File file, bool paused);
 	bool play(const char *filename);
 	bool play(const char *filename, bool paused); //start in paused state?
-#if !defined(KINETISL)
 	bool addMemoryForRead(size_t mult); //add memory
-#endif
 	void togglePlayPause(void);
 	void pause(bool pause);
 	void stop(void);

--- a/play_wav.h
+++ b/play_wav.h
@@ -31,20 +31,152 @@
 #include <Arduino.h>
 #include <AudioStream.h>
 #include <SD.h>
+#include <EventResponder.h>
 
 
 #define APW_ERR_OK              0 // no Error
 #define APW_ERR_FORMAT          1 // not supported Format
-#define APW_ERR_FILE   			2 // File not readable (does ist exist?)
+#define APW_ERR_FILE   			2 // File not readable (does it exist?)
 #define APW_ERR_OUT_OF_MEMORY   3 // Not enough dynamic memory available
-#define APW_ERR_NO_AUDIOBLOCKS  4
+#define APW_ERR_NO_AUDIOBLOCKS  4 // insufficient available audo blocks
 
+#define xDEBUG_PRINT_PLAYWAV
+#if defined(DEBUG_PRINT_PLAYWAV)
+#define SPLN(...) Serial.println(__VA_ARGS__)
+#define SPRT(...) Serial.print(__VA_ARGS__)
+#define SPTF(...) Serial.printf(__VA_ARGS__)
+#define SFSH(...) Serial.flush()
+#else
+#define SPLN(...) 
+#define SPRT(...) 
+#define SPTF(...) 
+#define SFSH(...) 
+#endif  // defined(DEBUG_PRINT_PLAYWAV)
 
 #if defined(KINETISL)
     const int _AudioPlayWav_MaxChannels = 2;
 #else
 	const int _AudioPlayWav_MaxChannels = 16;
 #endif
+
+class AudioPlayWav;
+
+/**
+ * Class to move WAV data from (and eventually to?) files using
+ * EventResponder to decouple interrupt demand from foreground
+ * data access. Of most use with SD cards.
+ */
+class WavMover
+{
+public:
+	WavMover() {}
+	bool play(File file); //!< prepare to play a file that's already open
+	
+	// Simple functions we can define immediately:
+	void readLater(void) //!< from interrupt: request re-fill the buffer
+		{ 
+			if (eventReadingEnabled)
+				evResp.triggerEvent(0,this); // do the read in the foreground: must delay() or yield()
+			else
+				read(buffer,sz_mem);		 // read immediately
+				
+		}
+		
+	int8_t* getBuffer() //!< return pointer to buffer holding WAV data
+		{ return buffer; }
+		
+	size_t getBufferSize() //!< return size of buffer
+		{ return sz_mem; }
+		
+	int8_t* createBuffer(size_t len) //!< allocate the buffer
+		{ 
+			sz_mem = len; 
+			buffer = (int8_t*) malloc(sz_mem); 
+			SPTF("Allocated %d bytes at %X - %X\r\n",sz_mem, buffer, buffer+sz_mem-1);
+			for (size_t i=0;i<len/2;i++) *((int16_t*) buffer+i) = i * 30000 / len;
+			return buffer;
+		}
+		
+	size_t read(void* buf,size_t len) //!< read len bytes immediately into buffer provided
+		{ 
+			uint32_t tmp = ARM_DWT_CYCCNT;
+			size_t result = wavfile.read(buf,len);
+			
+			if ( result < len ) 
+				memset((int8_t*) buf+result, padding , len - result);				
+			SPTF("Read %d bytes to %x: fifth int16 is %d\r\n",len,buf,*(((int16_t*) buf)+4));
+			
+			// % CPU load per track per update cycle
+			lastReadLoad = ((ARM_DWT_CYCCNT - tmp) * AUDIO_BLOCK_SAMPLES / len)>>6;
+			
+			return result;
+		}
+		
+	void seek(size_t pos) //!< seek to new file position
+		{ wavfile.seek(pos); }
+		
+	size_t position() //!< return file position
+		{ return wavfile.position(); }
+		
+	void close() //!< close file, free up the buffer, detach responder
+		{ 
+			bool irq = stopInt();
+			
+			if (wavfile)  
+				wavfile.close();  
+			
+			if (nullptr != buffer) 
+			{ 
+				SPTF("\r\Freed %d bytes at %X - %X\r\n",sz_mem, buffer, buffer+sz_mem-1);
+				free(buffer); 
+				buffer = nullptr; 
+			}
+			
+			//evResp.detach();	
+			evResp.clearEvent(); // not intuitive, but works SO much better...
+			
+			startInt(irq);
+		}
+		
+	void setPadding(uint8_t b) { padding = b; }
+	
+	void enableEventReading(bool enable) { eventReadingEnabled = enable; }
+	
+	operator bool() {return wavfile;}
+	
+	uint32_t lastReadLoad;		//!< CPU load for last SD card read, spread over the number of audio blocks loaded
+	
+private:
+	bool stopInt()
+	{
+		if ( NVIC_IS_ENABLED(IRQ_SOFTWARE) )
+		{
+			NVIC_DISABLE_IRQ(IRQ_SOFTWARE);
+			return true;
+		}
+		return false;
+	}
+
+	void startInt(bool enabled)
+	{
+    if (enabled)
+        NVIC_ENABLE_IRQ(IRQ_SOFTWARE);
+	}	
+	
+	static void evFunc(EventResponderRef ref) //!< foreground: respond to request to load WAV data
+	{
+		WavMover& thisWM = *(WavMover*) ref.getData();
+		
+		SPRT("*** ");
+		thisWM.read(thisWM.buffer,thisWM.sz_mem);
+	}
+	EventResponder evResp; 			//!< executes data transfer in foreground
+	File wavfile;					//!< file if streaming to/from SD card
+	int8_t* buffer;					//!< buffer to store pre-loaded WAV data
+	size_t sz_mem;					//!< size of buffer	
+	uint8_t padding;				//!< value to pad buffer at EOF
+	static bool eventReadingEnabled;//!< true to read filesystem via EventResponder; otherwise inside update() as usual
+};
 
 
 class AudioPlayWav : public AudioStream
@@ -63,6 +195,7 @@ public:
 	bool isPaused(void);
 	bool isStopped(void);
 	uint32_t positionMillis(void);
+	uint32_t filePos(void);
 	uint32_t lengthMillis(void);
 	uint32_t numBits(void);
 	uint32_t numChannels(void);
@@ -70,8 +203,11 @@ public:
 	uint32_t channelMask(void);
 	uint8_t lastErr(void);              // returns last error
 	size_t memUsed(void);
+	size_t memRead(void);
 	uint8_t instanceID(void);
 	virtual void update(void);
+	void enableEventReading(bool enable) { wavMovr.enableEventReading(enable); }
+	float getCPUload() { return CYCLE_COUNTER_APPROX_PERCENT(wavMovr.lastReadLoad); }
 private:
     void begin(void);
 	bool readHeader(int newState);
@@ -79,9 +215,10 @@ private:
 	void stopUsingSPI(void);
     bool stopInt(void);
     void startInt(bool enabled);
-	File wavfile;
-	int8_t *buffer = nullptr;	        // buffer data
-	size_t sz_mem = 0;					// Size of allocated memory
+	WavMover wavMovr;
+	//File wavfile;
+	//int8_t *buffer = nullptr;	        // buffer data
+	//size_t sz_mem = 0;				// Size of allocated memory
 	size_t sz_frame;				    // Size of a sample frame in bytes
 	int data_length;		  	        // number of frames remaining in file
 	size_t buffer_rd;	                // where we're at consuming "buffer"	 Lesezeiger

--- a/play_wav.h
+++ b/play_wav.h
@@ -85,7 +85,7 @@ private:
 	int8_t *buffer = nullptr;	        // buffer data
 	size_t sz_mem = 0;					// Size of allocated memory
 	size_t sz_frame;				    // Size of a sample frame in bytes
-	size_t data_length;		  	        // number of frames remaining in file
+	int data_length;		  	        // number of frames remaining in file
 	size_t buffer_rd;	                // where we're at consuming "buffer"	 Lesezeiger
 	size_t total_length = 0;			// number of audio data bytes in file
 	unsigned int sample_rate = 0;

--- a/play_wav.h
+++ b/play_wav.h
@@ -225,11 +225,11 @@ private:
 	void stopUsingSPI(void);
     bool stopInt(void);
     void startInt(bool enabled);
+    void (*decoder)(int8_t buffer[], size_t *buffer_rd, audio_block_t *queue[], unsigned int channels);
 	WavMover wavMovr;
 	//File wavfile;
 	//int8_t *buffer = nullptr;	        // buffer data
 	//size_t sz_mem = 0;				// Size of allocated memory
-	size_t sz_frame;				    // Size of a sample frame in bytes
 	int data_length;		  	        // number of frames remaining in file
 	size_t buffer_rd;	                // where we're at consuming "buffer"	 Lesezeiger
 	size_t total_length = 0;			// number of audio data bytes in file


### PR DESCRIPTION
Defaults to old-style buffer re-loads within the interrupt-driven update() function, but can be switched to event-driven mode by calling AudioPlayWav::enableEventReading(true); switch back with AudioPlayWav::enableEventReading(false). 

Destructors added and other minor changes to make it compatible with Dynamic Audio Objects.

Made addmemoryForRead() static, since it's global to all instances: allows AudioPlayWav::addmemoryForRead() call prior to creating any AudioPlayWav objects.