### PR TITLE
Typo fix and correct problems

### DIFF
--- a/README.md
+++ b/README.md
@@ -50,7 +50,7 @@ While playing, return the current time offset, in milliseconds.  When not playin
 #### lengthMillis()
 Return the total length of the current sound clip,in milliseconds. When not playing, the return from this function is undefined.
 #### addMemoryForRead(mult) [static]
-To make SD reads less frequent, additional buffer memory may be allocated: this should be done prior to calling `play()`. The value of `nult` actually scales the allocated memory, so `2` will double it (and thus halve the read frequency), `1` will allocate the normal minimum. The `mult` value given is used for all objects.
+To make SD reads less frequent, additional buffer memory may be allocated: this should be done prior to calling `play()`. The value of `mult` actually scales the allocated memory, so `2` will double it (and thus halve the read frequency), `1` will allocate the normal minimum. The `mult` value given is used for all objects.
 #### enableEventReading(bool) [static]
 By default SD card reads occur within the (interrupt driven) audio update cycle. By calling this function with a `true` parameter, SD card reads instead occur within the "foreground" code, using the EventResponder mechanism. Switching between mechanisms may be done at any time, even while playing is in progress, though there *may* be some loss of synchronisation.
 

--- a/play_wav.h
+++ b/play_wav.h
@@ -213,7 +213,7 @@ public:
 	uint32_t channelMask(void) {return channelmask;};
     uint32_t lengthMillis(void) {return total_length * (1000.0f / AUDIO_SAMPLE_RATE_EXACT);};
     #if USE_EVENTRESPONDER_PLAYWAV
-	static void enableEventReading(bool enable) { enableEventReading(enable); }
+	static void enableEventReading(bool enable) { AudioBaseWav::enableEventReading(enable); }
     #endif
 private:
     virtual void update(void);
@@ -235,6 +235,7 @@ public:
     AudioRecordWav(void): AudioStream(_AudioRecordWav_MaxChannels, queue) { begin(); }
     ~AudioRecordWav(void) { end(); }
     void stop(bool closeFile = true);
+    void pause(const bool pause);
 
     bool record(File file, APW_FORMAT fmt, unsigned int channels, bool paused = false);
     bool record(const char *filename, APW_FORMAT fmt, unsigned int channels, bool paused = false);
@@ -255,7 +256,6 @@ private:
     virtual void update(void);
     void begin(void);
     void end(void);
-    void pause(const bool pause);
     size_t (*encoder)(int8_t buffer[], size_t buffer_rd, audio_block_t *queue[], const unsigned int channels);
     audio_block_t *queue[_AudioRecordWav_MaxChannels];
     size_t sz_frame;


### PR DESCRIPTION
README.md - correct "mult"
play_wav.h - make AudioPlayWav::enableEventReading work, rather than recurse!; make AudioPlayWav::pause() public