### PR TITLE
Double-buffered record

### DIFF
--- a/examples/WaveRecordSweep/WaveRecordSweep.ino
+++ b/examples/WaveRecordSweep/WaveRecordSweep.ino
@@ -1,7 +1,10 @@
 
 #include <Audio.h>
 #include <play_wav.h>
-/*
+
+#define xHAVE_PT8211
+
+#if defined(HAVE_PT8211)
 AudioSynthToneSweep myEffect;
 AudioOutputPT8211   audioOutput;
 AudioRecordWav      record;
@@ -13,12 +16,8 @@ AudioConnection c2(play, 0, audioOutput, 1);
 AudioConnection c3(myEffect, 0, record, 0);
 AudioConnection c4(myEffect, 0, record, 1);
 
-#include <Audio.h>
-#include <Wire.h>
-#include <SPI.h>
-#include <SD.h>
-#include <SerialFlash.h>
-*/
+#else
+
 // GUItool: begin automatically generated code
 AudioPlayWav             play;       //xy=288,291
 AudioSynthToneSweep      myEffect;     //xy=288,382
@@ -33,6 +32,7 @@ AudioConnection          patchCord5(myEffect, 0, record, 0);
 AudioConnection          patchCord6(myEffect, 0, record, 1);
 AudioControlSGTL5000     sgtl5000_1;     //xy=466,205
 // GUItool: end automatically generated code
+#endif // defined(HAVE_PT8211)
 
 
 
@@ -48,8 +48,11 @@ File file;
 void setup(void)
 {
   AudioMemory(20);
+  
+#if !defined(HAVE_PT8211)
   sgtl5000_1.enable();
-  sgtl5000_1.volume(0.5);
+  sgtl5000_1.volume(0.1);
+#endif // defined(HAVE_PT8211)
 
   Serial.begin(9600);
 

--- a/play_wav.cpp
+++ b/play_wav.cpp
@@ -226,7 +226,7 @@ int8_t* AudioBaseWav::createBuffer(size_t len) //!< allocate the buffer
 	firstHalf = true; // start by using first half, if we're double-buffering
 	count = 0; // zero count of times we've attempted to write from this buffer
 
-    Serial.printf("Allocated %d aligned bytes at %X - %X\r\n",sz_mem, buffer, buffer+sz_mem-1);
+    //Serial.printf("Allocated %d aligned bytes at %X - %X\r\n",sz_mem, buffer, buffer+sz_mem-1);
     for (size_t i=0;i<len/2;i++) *((int16_t*) buffer+i) = i * 30000 / len;
     return buffer;
 }
@@ -1453,20 +1453,12 @@ void  AudioRecordWav::update(void)
         queue[chan] = q;
 	} while (++chan < channels);
 
-    buffer_wr += encoder(buffer, buffer_wr, queue, channels) * channels;
+    buffer_wr += encoder(getBuffer(), buffer_wr, queue, channels) * channels;
 	size_t sz_mem = getBufferSize() / 2; // recording uses double-buffering
     if (buffer_wr >= sz_mem)
     {
         buffer_wr = 0;
 		writeLater(); // may be immediate if not using EventResponder
-		/*
-        size_t wr = write(buffer , sz_mem);
-        if (wr < sz_mem) {
-            stop(false); //Disk full, max filesize reached, SD Card removed etc.
-            last_err = ERR_FILE;
-			return;
-        }
-		*/
     }
 
     ++data_length;

--- a/play_wav.h
+++ b/play_wav.h
@@ -90,7 +90,7 @@ enum APW_ERR { ERR_OK = 0,              // no Error
 #endif
 
 
-enum APW_STATE {STATE_STOP, STATE_PAUSED, STATE_RUNNING};
+enum APW_STATE {STATE_STOP, STATE_PAUSED, STATE_RUNNING, STATE_ABORT};
 
 class AudioPlayWav;
 class AudioRecordWav;
@@ -143,7 +143,10 @@ private:
     ~AudioBaseWav(void){ close(); }
 
 	int8_t* createBuffer(size_t len); //!< allocate the buffer
-    inline int8_t* getBuffer() { return buffer; } //!< return pointer to buffer holding WAV data
+	bool firstHalf;						//!< if double-buffering, true to use first half
+	int16_t count;
+    inline int8_t* getBuffer() { return buffer + (firstHalf?0:(sz_mem/2)); } //!< return pointer to buffer holding WAV data
+    inline int8_t* getOtherBuffer() { return buffer + ((!firstHalf)?0:(sz_mem/2)); } //!< return pointer to buffer holding WAV data
 
     inline bool seek(size_t pos) { return wavfile.seek(pos); }//!< seek to new file position
     inline void flush(void) { wavfile.flush(); }


### PR DESCRIPTION
Sorry, I edited WaveRecordSweep.ino to (optionally) work with my hardware - please revert that if you prefer!

Works a lot better with my "torture test" example, but needs double-buffered playback to be properly clean.